### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-#Bitmap Smart Clipping using OpenCV
+# Bitmap Smart Clipping using OpenCV
 
 ### based on [http://code.taobao.org/p/tclip/](http://code.taobao.org/p/tclip/)
 
 #### recommend iOS version: [https://github.com/croath/UIImageView-BetterFace](https://github.com/croath/UIImageView-BetterFace)
 
-#Demo Screenshots
+# Demo Screenshots
 
 ![demo screenshots](https://raw.github.com/beartung/tclip-android/master/screenshots/s1.png "Demo Screenshots")
 
 
-#Features
+# Features
 
 * using OpenCV to detect faces firstly, if have faces, won't cut faces off
 * using OpenCV to detect other characters secondly, if found significant zone, won't cut it off
 * using FAST feature detector instead of SURF, thanks for [@yanunon](https://github.com/yanunon)
 
-#Usage
+# Usage
 
 * copy config file to app dir
 
@@ -30,7 +30,7 @@
     Bitmap ret = TClip.crop(configPath, sourceBitmap, width, height);
     ```
 
-#Build
+# Build
 
 * download OpenCV & unzip to /home/user/opencv-android-sdk
 * export OPENCV_PACKAGE_DIR="/home/user/opencv-android-sdk"


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
